### PR TITLE
[FIX][Issue = 14]. Unfocus when fling the backdrop to avoid keyboard …

### DIFF
--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -194,7 +194,7 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
   }
 
   void fling() {
-    FocusScope.of(context).unfocus();
+    FocusScope.of(context)?.unfocus();
     controller.fling(velocity: isTopPanelVisible ? -1.0 : 1.0);
   }
 

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -193,7 +193,10 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
         status == AnimationStatus.reverse;
   }
 
-  void fling() => controller.fling(velocity: isTopPanelVisible ? -1.0 : 1.0);
+  void fling() {
+    FocusScope.of(context).unfocus();
+    controller.fling(velocity: isTopPanelVisible ? -1.0 : 1.0);
+  }
 
   void showBackLayer() {
     if (isTopPanelVisible) controller.fling(velocity: -1.0);


### PR DESCRIPTION
Good Afternoon.
This PR is mainly to Unfocus the backdrop adding FocusScope.of(context).unfocus(); in fling function that is called when is clicked the leading button in the action bar or when it is clicked in the actions buttons with BackdropToggleButton.
KR,
JAPM