### PR TITLE
Configurable inactive layer color + animating color change

### DIFF
--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -127,6 +127,12 @@ class BackdropScaffold extends StatefulWidget {
   /// Defaults to `true`.
   final bool resizeToAvoidBottomInset;
 
+  /// Defines the color for the inactive front layer.
+  /// Implicitly an opacity of 0.7 is applied to the passed color.
+  ///
+  /// Defaults to `const Color(0xFFEEEEEE)`.
+  final Color inactiveOverlayColor;
+
   /// Creates a backdrop scaffold to be used as a material widget.
   BackdropScaffold({
     this.controller,
@@ -143,6 +149,7 @@ class BackdropScaffold extends StatefulWidget {
     this.stickyFrontLayer = false,
     this.animationCurve = Curves.linear,
     this.resizeToAvoidBottomInset = true,
+    this.inactiveOverlayColor = const Color(0xFFEEEEEE),
   });
 
   @override
@@ -238,15 +245,18 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
 
   Widget _buildInactiveLayer(BuildContext context) {
     return Offstage(
-      offstage: isTopPanelVisible,
-      child: GestureDetector(
-        onTap: () => fling(),
-        behavior: HitTestBehavior.opaque,
-        child: SizedBox.expand(
-          child: Container(
-            decoration: BoxDecoration(
-              borderRadius: widget.frontLayerBorderRadius,
-              color: Colors.grey.shade200.withOpacity(0.7),
+      offstage: controller.status == AnimationStatus.completed,
+      child: FadeTransition(
+        opacity: Tween(begin: 1.0, end: 0.0).animate(controller),
+        child: GestureDetector(
+          onTap: () => fling(),
+          behavior: HitTestBehavior.opaque,
+          child: SizedBox.expand(
+            child: Container(
+              decoration: BoxDecoration(
+                borderRadius: widget.frontLayerBorderRadius,
+                color: widget.inactiveOverlayColor.withOpacity(0.7),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Added property `inactiveOverlayColor` to BackdropScaffold, which enables to set the color of the inactive front layer.
The color change is now animated using the same `AnimationController` as the backdrop animation.

This now makes the color of the inactive layer customizable. However, it doesn't allow to only change the front layer's opacity, as mentioned in #2. In the backdrop material design specification I couldn't find anything stating that the front layer should be changed in its opacity. Therefore, I think this is a good solution or at least it is better than before. @daadu what do you think?

Closes #2.