### PR TITLE
Improve the front layer border radius

### DIFF
--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -273,11 +273,14 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
     return Material(
       elevation: 12.0,
       borderRadius: widget.frontLayerBorderRadius,
-      child: Stack(
-        children: <Widget>[
-          widget.frontLayer,
-          _buildInactiveLayer(context),
-        ],
+      child: ClipRRect(
+        borderRadius: widget.frontLayerBorderRadius,
+        child: Stack(
+          children: <Widget>[
+            widget.frontLayer,
+            _buildInactiveLayer(context),
+          ],
+        ),
       ),
     );
   }

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -271,7 +271,7 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
 
   Widget _buildFrontPanel(BuildContext context) {
     return Material(
-      elevation: 12.0,
+      elevation: 1.0,
       borderRadius: widget.frontLayerBorderRadius,
       child: ClipRRect(
         borderRadius: widget.frontLayerBorderRadius,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ authors:
   - Flutter Community <community@flutter.zone>
   - Harsh Bhikadia <harsh.bhikadiya@gmail.com>
   - Felix Wielander <felix.wielander@gmail.com>
+  - Daniel Borges <https://github.com/danielborges93>
 
 environment:
   sdk: ">=1.19.0 <3.0.0"


### PR DESCRIPTION
The border radius is not painted properly when the front layer is a colored `Container`.

## Code example
```dart
// My theme
final appTheme = ThemeData(
  primaryColor: Color(0xfffafafa), // white
  primaryColorDark: Color(0xff00a651) // green
);

// My BackdropScafold
class MainScreen extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return BackdropScaffold(
      title: Text('Title...'),
      backLayer: Center(
        child: Text('Back'),
      ),
      frontLayer: Container(
        color: Theme.of(context).primaryColorDark,
        child: Center(
          child: Text('Front'),
        ),
      ),
      animationCurve: Curves.easeInOut,
    );
  }
}
```

## Before
![Screenshot_1590204593](https://user-images.githubusercontent.com/1283243/82720951-b853a500-9c8e-11ea-8aaf-24a54b72bdb9.png)
![Screenshot_1590204610](https://user-images.githubusercontent.com/1283243/82721006-6c553000-9c8f-11ea-940a-fec61a49015a.png)

## After
![Screenshot_1590204693](https://user-images.githubusercontent.com/1283243/82721016-a7576380-9c8f-11ea-8b7d-b841831dbff6.png)
![Screenshot_1590204698](https://user-images.githubusercontent.com/1283243/82721021-ac1c1780-9c8f-11ea-93a5-d262ec6425ef.png)