### PR TITLE
Added callbacks for backdrop events

### DIFF
--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -263,7 +263,7 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
   void showBackLayer() {
     if (isTopPanelVisible) {
       controller.animateBack(-1.0);
-      widget.onCollapse?.call();
+      widget.onBackLayerVisible?.call();
     }
   }
 

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -164,6 +164,12 @@ class BackdropScaffold extends StatefulWidget {
   /// Defaults to `const Color(0xFFEEEEEE)`.
   final Color inactiveOverlayColor;
 
+  /// Will be called when front layer expands
+  final VoidCallback onExpand;
+
+  /// Will be called when front layer collapses
+  final VoidCallback onCollapse;
+
   /// Creates a backdrop scaffold to be used as a material widget.
   BackdropScaffold({
     this.controller,
@@ -192,7 +198,9 @@ class BackdropScaffold extends StatefulWidget {
     this.floatingActionButton,
     this.inactiveOverlayColor = const Color(0xFFEEEEEE),
     this.floatingActionButtonLocation,
-    this.floatingActionButtonAnimator
+    this.floatingActionButtonAnimator,
+	  this.onExpand,
+	  this.onCollapse
   });
 
   @override
@@ -254,10 +262,12 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
 
   void showBackLayer() {
     if (isTopPanelVisible) controller.animateBack(-1.0);
+    widget.onCollapse?.call();
   }
 
   void showFrontLayer() {
     if (isBackPanelVisible) controller.animateTo(1.0);
+    widget.onExpand?.call();
   }
 
   double _getBackPanelHeight() =>

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -199,8 +199,8 @@ class BackdropScaffold extends StatefulWidget {
     this.inactiveOverlayColor = const Color(0xFFEEEEEE),
     this.floatingActionButtonLocation,
     this.floatingActionButtonAnimator,
-    this.onExpand,
-    this.onCollapse,
+    this.onFrontLayerVisible,
+    this.onBackLayerVisible,
   });
 
   @override

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -199,8 +199,8 @@ class BackdropScaffold extends StatefulWidget {
     this.inactiveOverlayColor = const Color(0xFFEEEEEE),
     this.floatingActionButtonLocation,
     this.floatingActionButtonAnimator,
-	  this.onExpand,
-	  this.onCollapse
+    this.onExpand,
+    this.onCollapse
   });
 
   @override
@@ -262,15 +262,15 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
 
   void showBackLayer() {
     if (isTopPanelVisible) {
-    	controller.animateBack(-1.0);
-	    widget.onCollapse?.call();
+      controller.animateBack(-1.0);
+      widget.onCollapse?.call();
     }
   }
 
   void showFrontLayer() {
     if (isBackPanelVisible) {
-    	controller.animateTo(1.0);
-	    widget.onExpand?.call();
+      controller.animateTo(1.0);
+      widget.onExpand?.call();
     }
   }
 

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -270,7 +270,7 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
   void showFrontLayer() {
     if (isBackPanelVisible) {
       controller.animateTo(1.0);
-      widget.onExpand?.call();
+      widget.onFrontLayerVisible?.call();
     }
   }
 

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -200,7 +200,7 @@ class BackdropScaffold extends StatefulWidget {
     this.floatingActionButtonLocation,
     this.floatingActionButtonAnimator,
     this.onExpand,
-    this.onCollapse
+    this.onCollapse,
   });
 
   @override

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -242,7 +242,7 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
   }
 
   @Deprecated("Replace by the use of `isBackLayerConcealed`."
-      "This feature was deprecated after v1.0.0.")
+      "This feature was deprecated after v0.3.3.")
   bool get isTopPanelVisible => isBackLayerConcealed;
 
   bool get isBackLayerConcealed =>
@@ -250,7 +250,7 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
       controller.status == AnimationStatus.forward;
 
   @Deprecated("Replace by the use of `isBackLayerRevealed`."
-      "This feature was deprecated after v1.0.0.")
+      "This feature was deprecated after v0.3.3.")
   bool get isBackPanelVisible => isBackLayerRevealed;
 
   bool get isBackLayerRevealed =>
@@ -267,7 +267,7 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
   }
 
   @Deprecated("Replace by the use of `revealBackLayer`."
-      "This feature was deprecated after v1.0.0.")
+      "This feature was deprecated after v0.3.3.")
   void showBackLayer() => revealBackLayer();
 
   void revealBackLayer() {
@@ -278,7 +278,7 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
   }
 
   @Deprecated("Replace by the use of `concealBackLayer`."
-      "This feature was deprecated after v1.0.0.")
+      "This feature was deprecated after v0.3.3.")
   void showFrontLayer() => concealBackLayer();
 
   void concealBackLayer() {

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -164,10 +164,10 @@ class BackdropScaffold extends StatefulWidget {
   /// Defaults to `const Color(0xFFEEEEEE)`.
   final Color inactiveOverlayColor;
 
-  /// Will be called when front layer expands
+  /// Will be called when front layer is visible
   final VoidCallback onFrontLayerVisible;
 
-  /// Will be called when front layer collapses
+  /// Will be called when back layer is visible
   final VoidCallback onBackLayerVisible;
 
   /// Creates a backdrop scaffold to be used as a material widget.

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -165,10 +165,10 @@ class BackdropScaffold extends StatefulWidget {
   final Color inactiveOverlayColor;
 
   /// Will be called when front layer expands
-  final VoidCallback onExpand;
+  final VoidCallback onFrontLayerVisible;
 
   /// Will be called when front layer collapses
-  final VoidCallback onCollapse;
+  final VoidCallback onBackLayerVisible;
 
   /// Creates a backdrop scaffold to be used as a material widget.
   BackdropScaffold({

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -261,13 +261,17 @@ class _BackdropScaffoldState extends State<BackdropScaffold>
   }
 
   void showBackLayer() {
-    if (isTopPanelVisible) controller.animateBack(-1.0);
-    widget.onCollapse?.call();
+    if (isTopPanelVisible) {
+    	controller.animateBack(-1.0);
+	    widget.onCollapse?.call();
+    }
   }
 
   void showFrontLayer() {
-    if (isBackPanelVisible) controller.animateTo(1.0);
-    widget.onExpand?.call();
+    if (isBackPanelVisible) {
+    	controller.animateTo(1.0);
+	    widget.onExpand?.call();
+    }
   }
 
   double _getBackPanelHeight() =>


### PR DESCRIPTION
I find it very useful to know when the front layer expands or collapses. It might come in handy if you want to change or do smt reactively. In my case, I needed to change toolbar title when state of frontLayer changes, so I added this feature.