### PR TITLE
Feature/navigation separatorbuilder

### DIFF
--- a/example/lib/navigation.dart
+++ b/example/lib/navigation.dart
@@ -33,6 +33,7 @@ class _MyAppState extends State<MyApp> {
             ListTile(title: Text("Widget 2")),
           ],
           onTap: (int position) => {setState(() => _currentIndex = position)},
+          separatorBuilder: (context, index) => Divider(),
         ),
       ),
     );

--- a/lib/navigation.dart
+++ b/lib/navigation.dart
@@ -45,6 +45,11 @@ class BackdropNavigationBackLayer extends StatelessWidget {
   /// Callback that is called whenever a list item is tapped by the user.
   final ValueChanged<int> onTap;
 
+  /// Customizable separator used with [ListView.separated].
+  @Deprecated("Replace by use of `separatorBuilder`."
+      "This feature was deprecated after v0.4.1.")
+  final Widget separator;
+
   /// Customizable separatorBuilder used with [ListView.separated].
   final IndexedWidgetBuilder separatorBuilder;
 
@@ -56,6 +61,7 @@ class BackdropNavigationBackLayer extends StatelessWidget {
     Key key,
     @required this.items,
     this.onTap,
+    this.separator,
     this.separatorBuilder,
   })  : assert(items != null),
         assert(items.isNotEmpty),
@@ -76,7 +82,8 @@ class BackdropNavigationBackLayer extends StatelessWidget {
           onTap?.call(position);
         },
       ),
-      separatorBuilder: separatorBuilder ?? (builder, position) => Container(),
+      separatorBuilder:
+          separatorBuilder ?? (builder, position) => separator ?? Container(),
     );
   }
 }

--- a/lib/navigation.dart
+++ b/lib/navigation.dart
@@ -45,8 +45,8 @@ class BackdropNavigationBackLayer extends StatelessWidget {
   /// Callback that is called whenever a list item is tapped by the user.
   final ValueChanged<int> onTap;
 
-  /// Customizable separator used with [ListView.separated].
-  final Widget separator;
+  /// Customizable separatorBuilder used with [ListView.separated].
+  final IndexedWidgetBuilder separatorBuilder;
 
   /// Creates an instance of [BackdropNavigationBackLayer] to be used with
   /// [BackdropScaffold].
@@ -56,7 +56,7 @@ class BackdropNavigationBackLayer extends StatelessWidget {
     Key key,
     @required this.items,
     this.onTap,
-    this.separator,
+    this.separatorBuilder,
   })  : assert(items != null),
         assert(items.isNotEmpty),
         super(key: key);
@@ -76,7 +76,7 @@ class BackdropNavigationBackLayer extends StatelessWidget {
           onTap?.call(position);
         },
       ),
-      separatorBuilder: (builder, position) => separator ?? Container(),
+      separatorBuilder: separatorBuilder ?? (builder, position) => Container(),
     );
   }
 }


### PR DESCRIPTION
Replaces `separator` property of `BackdropNavigationBackLayer` with `separatorBuilder`.

Closes #43.

Could possibly be added before merging #37, but also afterwards...