### PR TITLE
feat: variable front page height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.5.0]
+
+* **BREAKING**: requires Dart >= 2.3
+* `BackdropScaffold`: added `frontLayerActiveFactor` [#73][]
+
+[#73]: https://github.com/fluttercommunity/backdrop/pull/73
+
 ## [0.4.7] - 28 October 2020
 
 * `BackdropScaffold`: added `scaffoldKey` [https://github.com/fluttercommunity/backdrop/pull/64]

--- a/example/lib/menu_variable_height_front_layer.dart
+++ b/example/lib/menu_variable_height_front_layer.dart
@@ -1,0 +1,84 @@
+import 'package:backdrop/backdrop.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(MyApp());
+
+/// Showcase for a Material Backdrop acting as a menu.
+class MyApp extends StatefulWidget {
+  @override
+  _MyAppState createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  int _currentIndex = 0;
+
+  final List<Widget> _pages = [
+    _TallPage(),
+    ...List.generate(9, (i) => _ShortPage(i + 1)),
+  ];
+
+  final _nav = List.generate(
+      10,
+      (i) => ListTile(
+          title: Text('Menu: open page #$i',
+              style: TextStyle(color: Colors.white))));
+
+  double get _heightFactor => _currentIndex == 0 ? 1 : (.1 * _currentIndex);
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+      title: 'Backdrop Demo',
+      home: BackdropScaffold(
+          appBar: BackdropAppBar(title: Text("AppBar is OK 👍")),
+          frontLayer: _pages[_currentIndex],
+          stickyFrontLayer: true,
+          backLayerScrim: Colors.red.withOpacity(0.5),
+          frontLayerScrim: Colors.green.withOpacity(0.5),
+          frontLayerActiveFactor: _heightFactor,
+          subHeader: BackdropSubHeader(title: Text('Subheader')),
+          backLayer: BackdropNavigationBackLayer(
+              items: _nav,
+              onTap: (int position) =>
+                  {setState(() => _currentIndex = position)},
+              separatorBuilder: (_, __) => _MyDivider())));
+}
+
+class _MyDivider extends StatelessWidget {
+  const _MyDivider();
+
+  @override
+  Widget build(BuildContext context) =>
+      Divider(indent: 16, endIndent: 16, color: Colors.white);
+}
+
+/// When the front layer doesn't have much content, its height while revealed
+/// is configurable via [BackdropScaffold.frontLayerActiveFactor].
+class _ShortPage extends StatelessWidget {
+  final int index;
+
+  _ShortPage(this.index);
+
+  @override
+  Widget build(BuildContext context) => Center(
+          child: Column(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+            Text("Page #$index is open with desired height."),
+            const Flexible(child: FractionallySizedBox(heightFactor: 0.1)),
+            Text("It looks better! 😄"),
+            const Flexible(child: FractionallySizedBox(heightFactor: 0.1)),
+            Text("But Page #0 still needs to be tall."),
+          ]));
+}
+
+/// A front layer with a lot of content should reveal to show as much as possible.
+class _TallPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => ListView(
+      children: List.generate(
+          20,
+          (index) => Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text("Tall page #0, lots of content 👍"))));
+}

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -146,6 +146,15 @@ class BackdropScaffold extends StatefulWidget {
   /// If null, the color is handled automatically according to the theme.
   final Color frontLayerBackgroundColor;
 
+  /// Fraction of the available height the front layer will occupy,
+  /// when active.  Clamped to (0, 1).
+  ///
+  /// Note the front layer will not fully conceal the back layer when
+  /// this value is less than 1.
+  ///
+  /// Defaults to 1.0.
+  final double frontLayerActiveFactor;
+
   /// Defines the color for the inactive front layer.
   /// A default opacity of 0.7 is applied to the passed color.
   /// See [inactiveOverlayOpacity].
@@ -271,6 +280,7 @@ class BackdropScaffold extends StatefulWidget {
     this.stickyFrontLayer = false,
     this.animationCurve = Curves.easeInOut,
     this.frontLayerBackgroundColor,
+    double frontLayerActiveFactor = 1.0,
     this.backLayerBackgroundColor,
     this.inactiveOverlayColor = const Color(0xFFEEEEEE),
     this.inactiveOverlayOpacity = 0.7,
@@ -297,6 +307,7 @@ class BackdropScaffold extends StatefulWidget {
     this.drawerEnableOpenDragGesture = true,
     this.endDrawerEnableOpenDragGesture = true,
   })  : assert(inactiveOverlayOpacity >= 0.0 && inactiveOverlayOpacity <= 1.0),
+        frontLayerActiveFactor = frontLayerActiveFactor.clamp(0, 1).toDouble(),
         super(key: key);
 
   @override
@@ -453,7 +464,8 @@ class BackdropScaffoldState extends State<BackdropScaffold>
     }
     return RelativeRectTween(
       begin: RelativeRect.fromLTRB(0.0, backPanelHeight, 0.0, frontPanelHeight),
-      end: RelativeRect.fromLTRB(0.0, 0.0, 0.0, 0.0),
+      end: RelativeRect.fromLTRB(
+          0.0, availableHeight * (1 - widget.frontLayerActiveFactor), 0.0, 0.0),
     ).animate(CurvedAnimation(
       parent: controller,
       curve: widget.animationCurve,

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -327,6 +327,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
     with SingleTickerProviderStateMixin {
   bool _shouldDisposeController = false;
   AnimationController _controller;
+  ColorTween _scrimColorTween;
 
   /// Key for accessing the [ScaffoldState] of [BackdropScaffold]'s internally
   /// used [Scaffold].
@@ -354,6 +355,9 @@ class BackdropScaffoldState extends State<BackdropScaffold>
             vsync: this, duration: Duration(milliseconds: 200), value: 1.0);
     if (widget.controller == null) _shouldDisposeController = true;
 
+    _scrimColorTween = _buildScrimColorTween();
+
+    _controller.addListener(() => setState(() {}));
     _controller.addStatusListener((status) {
       setState(() {
         // This is intentionally left empty. The state change itself takes
@@ -363,6 +367,14 @@ class BackdropScaffoldState extends State<BackdropScaffold>
         // see https://github.com/flutter/flutter/pull/55414/commits/72d7d365be6639271a5e88ee3043b92833facb79
       });
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant BackdropScaffold oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.drawerScrimColor != widget.drawerScrimColor) {
+      _scrimColorTween = _buildScrimColorTween();
+    }
   }
 
   @override
@@ -562,6 +574,11 @@ class BackdropScaffoldState extends State<BackdropScaffold>
     return true;
   }
 
+  ColorTween _buildScrimColorTween() => ColorTween(
+        begin: Colors.transparent,
+        end: widget.drawerScrimColor ?? Colors.black54,
+      );
+
   Widget _buildBody(BuildContext context) {
     return WillPopScope(
       onWillPop: () => _willPopCallback(context),
@@ -587,7 +604,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
                   _buildBackPanel(),
                   if (isBackLayerConcealed && widget.frontLayerActiveFactor < 1)
                     Container(
-                        color: widget.drawerScrimColor,
+                        color: _scrimColorTween.evaluate(controller),
                         height: _backPanelHeight),
                   PositionedTransition(
                     rect: _getPanelAnimation(context, constraints),

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -614,10 +614,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
                 fit: StackFit.expand,
                 children: <Widget>[
                   _buildBackPanel(),
-                  if (isBackLayerConcealed && widget.frontLayerActiveFactor < 1)
-                    Container(
-                        color: _backLayerScrimColorTween.evaluate(controller),
-                        height: _backPanelHeight),
+                  if (_hasBackLayerScrim) _buildBackLayerScrim(),
                   PositionedTransition(
                     rect: _getPanelAnimation(context, constraints),
                     child: _buildFrontPanel(context),
@@ -648,6 +645,13 @@ class BackdropScaffoldState extends State<BackdropScaffold>
       ),
     );
   }
+
+  Container _buildBackLayerScrim() => Container(
+      color: _backLayerScrimColorTween.evaluate(controller),
+      height: _backPanelHeight);
+
+  bool get _hasBackLayerScrim =>
+      isBackLayerConcealed && widget.frontLayerActiveFactor < 1;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -81,11 +81,11 @@ class BackdropScaffold extends StatefulWidget {
 
   /// The widget shown at the top of the front layer.
   ///
-  /// When the front layer is minimized, the entire [subHeader] will be visible unless
+  /// When the front layer is minimized (back layer revealed), the entire [subHeader] will be visible unless
   /// [headerHeight] is specified.
   final Widget subHeader;
 
-  /// If true, the scrim applied to the front layer while minimized will not
+  /// If true, the scrim applied to the front layer while minimized (back layer revealed) will not
   /// cover the [subHeader].  See [frontLayerScrim].
   ///
   /// Defaults to true.
@@ -96,15 +96,14 @@ class BackdropScaffold extends StatefulWidget {
   /// Actions passed to [AppBar.actions].
   final List<Widget> actions;
 
-  /// Defines the front layer's height when minimized (revealing the back layer).
-  /// If this value is omitted but [subHeader] is provided, its measured height is used.
-  /// Defaults to 32 otherwise.
+  /// Defines the front layer's height when minimized (back layer revealed)).
+  /// Defaults to measured height of [subHeader] if provided, else 32.
   ///
   /// To automatically use the difference of the screen height and back layer's height,
   /// see [stickyFrontLayer].  Note [headerHeight] is ignored if it is less
   /// than the available size and [stickyFrontLayer] is `true`.
   ///
-  /// To vary the front layer's height when active (concealing the back layer),
+  /// To vary the front layer's height when active (back layer concealed),
   /// see [frontLayerActiveFactor].
   final double headerHeight;
 
@@ -152,7 +151,7 @@ class BackdropScaffold extends StatefulWidget {
   final Color frontLayerBackgroundColor;
 
   /// Fraction of the available height the front layer will occupy,
-  /// when active (concealing the back layer).  Clamped to (0, 1).
+  /// when active (back layer concealed).  Clamped to (0, 1).
   ///
   /// Note the front layer will not fully conceal the back layer when
   /// this value is less than 1.  A scrim will cover the

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -522,23 +522,28 @@ class BackdropScaffoldState extends State<BackdropScaffold>
   }
 
   Widget _buildBackPanel() {
-    return FocusScope(
-      canRequestFocus: isBackLayerRevealed,
-      child: Material(
-        color:
-            widget.backLayerBackgroundColor ?? Theme.of(context).primaryColor,
-        child: Column(
-          children: <Widget>[
-            Flexible(
-              child: _MeasureSize(
-                onChange: (size) =>
-                    setState(() => _backPanelHeight = size.height),
-                child: widget.backLayer ?? Container(),
-              ),
+    return Stack(
+      children: [
+        FocusScope(
+          canRequestFocus: isBackLayerRevealed,
+          child: Material(
+            color: widget.backLayerBackgroundColor ??
+                Theme.of(context).primaryColor,
+            child: Column(
+              children: <Widget>[
+                Flexible(
+                  child: _MeasureSize(
+                    onChange: (size) =>
+                        setState(() => _backPanelHeight = size.height),
+                    child: widget.backLayer ?? Container(),
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
-      ),
+        if (_hasBackLayerScrim) _buildBackLayerScrim(),
+      ],
     );
   }
 
@@ -611,7 +616,6 @@ class BackdropScaffoldState extends State<BackdropScaffold>
                 fit: StackFit.expand,
                 children: <Widget>[
                   _buildBackPanel(),
-                  if (_hasBackLayerScrim) _buildBackLayerScrim(),
                   PositionedTransition(
                     rect: _getPanelAnimation(context, constraints),
                     child: _buildFrontPanel(context),

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -80,9 +80,15 @@ class BackdropScaffold extends StatefulWidget {
   final Widget frontLayer;
 
   /// The widget that is shown as sub-header on top of the front layer.
+  ///
+  /// When the front layer is minimized, the entire [subHeader] will be visible unless
+  /// [headerHeight] is specified.
   final Widget subHeader;
 
-  /// This boolean flag keeps subHeader active when [backLayer] is visible. Defaults to true.
+  /// If false, a scrim will cover the front layer when it is minimized.
+  /// See [inactiveOverlayColor].
+  ///
+  /// Defaults to true.
   final bool subHeaderAlwaysActive;
 
   /// Deprecated. Use [BackdropAppBar.actions].
@@ -90,19 +96,16 @@ class BackdropScaffold extends StatefulWidget {
   /// Actions passed to [AppBar.actions].
   final List<Widget> actions;
 
-  /// Defines the height of the front layer when it is in the opened state.
+  /// Defines the front layer's height when minimized (revealing the back layer).
+  /// If this value is omitted but [subHeader] is provided, its measured height is used.
+  /// Defaults to 32 otherwise.
   ///
-  /// This height value is only applied, if [stickyFrontLayer]
-  /// is set to `false` or if [stickyFrontLayer] is set to `true` and the back
-  /// layer's height is less than
-  /// [BoxConstraints.biggest.height]-[headerHeight].
+  /// To automatically use the difference of the screen height and back layer's height,
+  /// see [stickyFrontLayer].  Note [headerHeight] is ignored if it is less
+  /// than the available size and [stickyFrontLayer] is `true`.
   ///
-  /// [headerHeight] is interpreted as the height of the front layer's visible
-  /// part, when being opened. The back layer's height corresponds to
-  /// [BoxConstraints.biggest.height]-[headerHeight].
-  ///
-  ///
-  /// If [subHeader] is defined then height of subHeader otherwise defaults to 32.0.
+  /// To vary the front layer's height when active (concealing the back layer),
+  /// see [frontLayerActiveFactor].
   final double headerHeight;
 
   /// Defines the [BorderRadius] applied to the front layer.
@@ -124,10 +127,12 @@ class BackdropScaffold extends StatefulWidget {
   /// Defaults to [BackdropIconPosition.leading].
   final BackdropIconPosition iconPosition;
 
-  /// A flag indicating whether the front layer should stick to the height of
-  /// the back layer when being opened.
-  ///
+  /// Indicates the front layer should minimize to the back layer's
+  /// bottom edge.  Otherwise, see [headerHeight] to specify this value.
   /// Defaults to `false`.
+  ///
+  /// This parameter has no effect if the back layer's measured height
+  /// is greater than or equal to the screen height.
   final bool stickyFrontLayer;
 
   /// The animation curve passed to [Tween.animate]() when triggering
@@ -147,7 +152,7 @@ class BackdropScaffold extends StatefulWidget {
   final Color frontLayerBackgroundColor;
 
   /// Fraction of the available height the front layer will occupy,
-  /// when active.  Clamped to (0, 1).
+  /// when active (concealing the back layer).  Clamped to (0, 1).
   ///
   /// Note the front layer will not fully conceal the back layer when
   /// this value is less than 1.  A scrim will cover the

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -441,16 +441,14 @@ class BackdropScaffoldState extends State<BackdropScaffold>
   Animation<RelativeRect> _getPanelAnimation(
       BuildContext context, BoxConstraints constraints) {
     double backPanelHeight, frontPanelHeight;
-
-    if (widget.stickyFrontLayer &&
-        _backPanelHeight < constraints.biggest.height - _headerHeight) {
+    final availableHeight = constraints.biggest.height - _headerHeight;
+    if (widget.stickyFrontLayer && _backPanelHeight < availableHeight) {
       // height is adapted to the height of the back panel
       backPanelHeight = _backPanelHeight;
       frontPanelHeight = -_backPanelHeight;
     } else {
       // height is set to fixed value defined in widget.headerHeight
-      final height = constraints.biggest.height;
-      backPanelHeight = height - _headerHeight;
+      backPanelHeight = availableHeight;
       frontPanelHeight = -backPanelHeight;
     }
     return RelativeRectTween(

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -369,16 +369,13 @@ class BackdropScaffoldState extends State<BackdropScaffold>
 
     _backLayerScrimColorTween = _buildBackLayerScrimColorTween();
 
-    _controller.addListener(() => setState(() {}));
-    _controller.addStatusListener((status) {
-      setState(() {
-        // This is intentionally left empty. The state change itself takes
-        // place inside the AnimationController, so there's nothing to update.
-        // All we want is for the widget to rebuild and read the new animation
-        // state from the AnimationController.
-        // see https://github.com/flutter/flutter/pull/55414/commits/72d7d365be6639271a5e88ee3043b92833facb79
-      });
-    });
+    _controller.addListener(() => setState(() {
+          // This is intentionally left empty. The state change itself takes
+          // place inside the AnimationController, so there's nothing to update.
+          // All we want is for the widget to rebuild and read the new animation
+          // state from the AnimationController.
+          // see https://github.com/flutter/flutter/pull/55414/commits/72d7d365be6639271a5e88ee3043b92833facb79
+        }));
   }
 
   @override

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -521,8 +521,8 @@ class BackdropScaffoldState extends State<BackdropScaffold>
     return FocusScope(
       canRequestFocus: isBackLayerRevealed,
       child: Material(
-        color: this.widget.backLayerBackgroundColor ??
-            Theme.of(context).primaryColor,
+        color:
+            widget.backLayerBackgroundColor ?? Theme.of(context).primaryColor,
         child: Column(
           children: <Widget>[
             Flexible(
@@ -540,7 +540,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
 
   Widget _buildFrontPanel(BuildContext context) {
     return Material(
-      color: this.widget.frontLayerBackgroundColor,
+      color: widget.frontLayerBackgroundColor,
       elevation: 1,
       borderRadius: widget.frontLayerBorderRadius,
       child: ClipRRect(

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -150,7 +150,8 @@ class BackdropScaffold extends StatefulWidget {
   /// when active.  Clamped to (0, 1).
   ///
   /// Note the front layer will not fully conceal the back layer when
-  /// this value is less than 1.
+  /// this value is less than 1.  A scrim will cover the
+  /// partially concealed back layer if [drawerScrimColor] is provided.
   ///
   /// Defaults to 1.0.
   final double frontLayerActiveFactor;
@@ -584,6 +585,10 @@ class BackdropScaffoldState extends State<BackdropScaffold>
                 fit: StackFit.expand,
                 children: <Widget>[
                   _buildBackPanel(),
+                  if (isBackLayerConcealed && widget.frontLayerActiveFactor < 1)
+                    Container(
+                        color: widget.drawerScrimColor,
+                        height: _backPanelHeight),
                   PositionedTransition(
                     rect: _getPanelAnimation(context, constraints),
                     child: _buildFrontPanel(context),

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -508,9 +508,9 @@ class BackdropScaffoldState extends State<BackdropScaffold>
           behavior: HitTestBehavior.opaque,
           child: Column(
             children: <Widget>[
-              // if subHeaderAlwaysActive then do not apply inactiveOverlayColor for area with _headerHeight
+              // if subHeaderAlwaysActive then do not apply frontLayerScrim for area with _subHeaderHeight
               widget.subHeader != null && widget.subHeaderAlwaysActive
-                  ? Container(height: _headerHeight)
+                  ? Container(height: _subHeaderHeight)
                   : Container(),
               Expanded(
                 child: Container(

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -398,12 +398,12 @@ class BackdropScaffoldState extends State<BackdropScaffold>
 
   /// Deprecated. Use [isBackLayerConcealed] instead.
   ///
-  /// Wether the back layer is concealed or not.
+  /// Whether the back layer is concealed or not.
   @Deprecated("Replace by the use of `isBackLayerConcealed`."
       "This feature was deprecated after v0.3.2.")
   bool get isTopPanelVisible => isBackLayerConcealed;
 
-  /// Wether the back layer is concealed or not.
+  /// Whether the back layer is concealed or not.
   bool get isBackLayerConcealed =>
       controller.status == AnimationStatus.completed ||
       controller.status == AnimationStatus.forward;

--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -113,8 +113,8 @@ class BackdropScaffold extends StatefulWidget {
   /// Defaults to
   /// ```dart
   /// const BorderRadius.only(
-  ///     topLeft: Radius.circular(16.0),
-  ///     topRight: Radius.circular(16.0),
+  ///     topLeft: Radius.circular(16),
+  ///     topRight: Radius.circular(16),
   /// )
   /// ```
   final BorderRadius frontLayerBorderRadius;
@@ -158,7 +158,7 @@ class BackdropScaffold extends StatefulWidget {
   /// this value is less than 1.  A scrim will cover the
   /// partially concealed back layer if [drawerScrimColor] is provided.
   ///
-  /// Defaults to 1.0.
+  /// Defaults to 1.
   final double frontLayerActiveFactor;
 
   /// Defines the color for the inactive front layer.
@@ -276,8 +276,8 @@ class BackdropScaffold extends StatefulWidget {
         this.actions = const <Widget>[],
     this.headerHeight,
     this.frontLayerBorderRadius = const BorderRadius.only(
-      topLeft: Radius.circular(16.0),
-      topRight: Radius.circular(16.0),
+      topLeft: Radius.circular(16),
+      topRight: Radius.circular(16),
     ),
     @Deprecated("Replace by use of BackdropAppBar. See BackdropAppBar.leading"
         "and BackdropAppBar.automaticallyImplyLeading."
@@ -286,7 +286,7 @@ class BackdropScaffold extends StatefulWidget {
     this.stickyFrontLayer = false,
     this.animationCurve = Curves.easeInOut,
     this.frontLayerBackgroundColor,
-    double frontLayerActiveFactor = 1.0,
+    double frontLayerActiveFactor = 1,
     this.backLayerBackgroundColor,
     this.inactiveOverlayColor = const Color(0xFFEEEEEE),
     this.inactiveOverlayOpacity = 0.7,
@@ -345,7 +345,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
   /// Defaults to
   /// ```dart
   /// AnimationController(
-  ///         vsync: this, duration: Duration(milliseconds: 200), value: 1.0)
+  ///         vsync: this, duration: Duration(milliseconds: 200), value: 1)
   /// ```
   AnimationController get controller => _controller;
 
@@ -357,7 +357,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
     // initialize _controller
     _controller = widget.controller ??
         AnimationController(
-            vsync: this, duration: Duration(milliseconds: 200), value: 1.0);
+            vsync: this, duration: Duration(milliseconds: 200), value: 1);
     if (widget.controller == null) _shouldDisposeController = true;
 
     _scrimColorTween = _buildScrimColorTween();
@@ -436,7 +436,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
   /// Animates the back layer to the "revealed" state.
   void revealBackLayer() {
     if (isBackLayerConcealed) {
-      controller.animateBack(-1.0);
+      controller.animateBack(-1);
       widget.onBackLayerRevealed?.call();
     }
   }
@@ -451,7 +451,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
   /// Animates the back layer to the "concealed" state.
   void concealBackLayer() {
     if (isBackLayerRevealed) {
-      controller.animateTo(1.0);
+      controller.animateTo(1);
       widget.onBackLayerConcealed?.call();
     }
   }
@@ -460,8 +460,8 @@ class BackdropScaffoldState extends State<BackdropScaffold>
     // if defined then use it
     if (widget.headerHeight != null) return widget.headerHeight;
 
-    // if no subHeader then 32.0
-    if (widget.subHeader == null) return 32.0;
+    // if no subHeader then 32
+    if (widget.subHeader == null) return 32;
 
     // if subHeader then height of subHeader
     return _subHeaderHeight;
@@ -481,9 +481,9 @@ class BackdropScaffoldState extends State<BackdropScaffold>
       frontPanelHeight = -backPanelHeight;
     }
     return RelativeRectTween(
-      begin: RelativeRect.fromLTRB(0.0, backPanelHeight, 0.0, frontPanelHeight),
+      begin: RelativeRect.fromLTRB(0, backPanelHeight, 0, frontPanelHeight),
       end: RelativeRect.fromLTRB(
-          0.0, availableHeight * (1 - widget.frontLayerActiveFactor), 0.0, 0.0),
+          0, availableHeight * (1 - widget.frontLayerActiveFactor), 0, 0),
     ).animate(CurvedAnimation(
       parent: controller,
       curve: widget.animationCurve,
@@ -494,7 +494,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
     return Offstage(
       offstage: controller.status == AnimationStatus.completed,
       child: FadeTransition(
-        opacity: Tween(begin: 1.0, end: 0.0).animate(controller),
+        opacity: Tween<double>(begin: 1, end: 0).animate(controller),
         child: GestureDetector(
           onTap: () => fling(),
           behavior: HitTestBehavior.opaque,
@@ -541,7 +541,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
   Widget _buildFrontPanel(BuildContext context) {
     return Material(
       color: this.widget.frontLayerBackgroundColor,
-      elevation: 1.0,
+      elevation: 1,
       borderRadius: widget.frontLayerBorderRadius,
       child: ClipRRect(
         borderRadius: widget.frontLayerBorderRadius,
@@ -595,7 +595,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
               actions: widget.iconPosition == BackdropIconPosition.action
                   ? <Widget>[BackdropToggleButton()] + widget.actions
                   : widget.actions,
-              elevation: 0.0,
+              elevation: 0,
               leading: widget.iconPosition == BackdropIconPosition.leading
                   ? BackdropToggleButton()
                   : null,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ authors:
   - Felix Wortmann <https://github.com/felixwortmann>
 
 environment:
-  sdk: ">=1.19.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Adds `double frontLayerActiveFactor` to `BackdropScaffold`.  See #70.

Optional: use `drawerScrimColor` to disable the back layer when it is partially concealed.

- BREAKING: bumps min sdk to Dart 2.3 for "[collection if](https://medium.com/dartlang/announcing-dart-2-3-optimized-for-building-user-interfaces-e84919ca1dff)"

## Default values leave existing behavior unchanged

![Screenshot from 2021-01-28 20-51-43](https://user-images.githubusercontent.com/705804/106221132-02404380-61ab-11eb-8a73-6820a3cd67cb.png)

![Screenshot from 2021-01-28 20-54-59](https://user-images.githubusercontent.com/705804/106221189-1dab4e80-61ab-11eb-8dab-3d9c926c5c37.png)

## New behavior

- Using `drawerScrimColor: Colors.black54`, `frontLayerActiveFactor: 0.2` (20% height)

![Screenshot from 2021-01-28 20-54-51](https://user-images.githubusercontent.com/705804/106221192-1f751200-61ab-11eb-9802-eca77c753c7d.png)

- Using `drawerScrimColor: Colors.black54`, `frontLayerActiveFactor: 0.5` (50% height)

![Screenshot from 2021-01-28 20-51-59](https://user-images.githubusercontent.com/705804/106221136-03717080-61ab-11eb-9bdb-1fd952b69108.png)

