### PR TITLE
Fix warning

### DIFF
--- a/lib/scaffold.dart
+++ b/lib/scaffold.dart
@@ -592,7 +592,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
                   child: _MeasureSize(
                     onChange: (size) =>
                         setState(() => _backPanelHeight = size.height),
-                    child: widget.backLayer ?? Container(),
+                    child: widget.backLayer,
                   ),
                 ),
               ],


### PR DESCRIPTION
```
scaffold.dart:595:35: Warning: Operand of null-aware operation '??' has type 'Widget' which excludes null.
 - 'Widget' is from 'package:flutter/src/widgets/framework.dart' ('../../dev/flutter/packages/flutter/lib/src/widgets/framework.dart').
                    child: widget.backLayer ?? Container(),
```