### PR TITLE
added a shadow to the front layer

### DIFF
--- a/lib/src/scaffold.dart
+++ b/lib/src/scaffold.dart
@@ -118,6 +118,11 @@ class BackdropScaffold extends StatefulWidget {
   /// Defaults to 1.
   final double frontLayerElevation;
 
+  /// Defines the shadow surrounding the front layer (cast upon the app bar).
+  ///
+  /// Defaults to an empty list in constructor.
+  final List<BoxShadow>? frontLayerBoxShadow;
+
   /// Indicates the front layer should minimize to the back layer's bottom edge.
   ///
   /// Otherwise, see [headerHeight] to specify this value.
@@ -296,6 +301,7 @@ class BackdropScaffold extends StatefulWidget {
       topRight: Radius.circular(16),
     ),
     this.frontLayerElevation = 1,
+    this.frontLayerBoxShadow = [],
     this.stickyFrontLayer = false,
     this.revealBackLayerAtStart = false,
     this.animationCurve = Curves.ease,
@@ -542,7 +548,7 @@ class BackdropScaffoldState extends State<BackdropScaffold>
   }
 
   Widget _buildFrontPanel(BuildContext context) {
-    return Material(
+    var frontPanel = Material(
       color: widget.frontLayerBackgroundColor,
       elevation: widget.frontLayerElevation,
       borderRadius: widget.frontLayerBorderRadius,
@@ -572,6 +578,16 @@ class BackdropScaffoldState extends State<BackdropScaffold>
         ),
       ),
     );
+    if (widget.frontLayerBoxShadow.isEmpty) {
+      return frontPanel;
+    }
+    // wrap in shadow if one is provided
+    return Stack(children: <Widget>[
+      Container(
+        decoration: BoxDecoration(boxShadow: widget.frontLayerBoxShadow),
+      ),
+      frontPanel,
+    ]);
   }
 
   Future<bool> _willPopCallback(BuildContext context) async {

--- a/lib/src/scaffold.dart
+++ b/lib/src/scaffold.dart
@@ -120,7 +120,7 @@ class BackdropScaffold extends StatefulWidget {
 
   /// Defines the shadow surrounding the front layer (cast upon the app bar).
   ///
-  /// Defaults to an empty list in constructor.
+  /// Defaults to null.
   final List<BoxShadow>? frontLayerBoxShadow;
 
   /// Indicates the front layer should minimize to the back layer's bottom edge.
@@ -301,7 +301,7 @@ class BackdropScaffold extends StatefulWidget {
       topRight: Radius.circular(16),
     ),
     this.frontLayerElevation = 1,
-    this.frontLayerBoxShadow = [],
+    this.frontLayerBoxShadow,
     this.stickyFrontLayer = false,
     this.revealBackLayerAtStart = false,
     this.animationCurve = Curves.ease,
@@ -578,10 +578,14 @@ class BackdropScaffoldState extends State<BackdropScaffold>
         ),
       ),
     );
-    if (widget.frontLayerBoxShadow.isEmpty) {
+    if (widget.frontLayerBoxShadow == null ||
+        widget.frontLayerBoxShadow!.isEmpty) {
       return frontPanel;
     }
-    // wrap in shadow if one is provided
+    return _wrapInShadow(frontPanel);
+  }
+
+  Widget _wrapInShadow(Widget frontPanel) {
     return Stack(children: <Widget>[
       Container(
         decoration: BoxDecoration(boxShadow: widget.frontLayerBoxShadow),


### PR DESCRIPTION
see https://github.com/fluttercommunity/backdrop/issues/112
I learned that the shadow was inverted since the front layer is within a Material widget. So in this feature we wrap the material widget Stack containing a Container with the given BoxShadow list. if no box shadow is provided, it works the same as before.

manually tested.

With this we can easily specify a drop shadow to be cast on the app bar and back layer.