### PR TITLE
fix: SchedulerBinding.instance is now null-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: "Install dependencies"
         run: flutter pub get && (cd demo && flutter pub get)
       - name: "Pub Check"
-        run: pub publish --dry-run
+        run: dart pub publish --dry-run
 
   check_formatting:
     name: "Check code formatting"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/checkout@v2
       - name: "Install Flutter"
         uses: subosito/flutter-action@v1
+        with:
+          channel: 'beta'
       - name: "Install dependencies"
         run: flutter pub get && (cd demo && flutter pub get)
       - name: "Analyze Dart code"
@@ -24,6 +26,8 @@ jobs:
         uses: actions/checkout@v2
       - name: "Install Flutter"
         uses: subosito/flutter-action@v1
+        with:
+          channel: 'beta'
       - name: "Install dependencies"
         run: flutter pub get && (cd demo && flutter pub get)
       - name: "Pub Check"
@@ -37,6 +41,8 @@ jobs:
         uses: actions/checkout@v2
       - name: "Install Flutter"
         uses: subosito/flutter-action@v1
+        with:
+          channel: 'beta'
       - name: "Install dependencies"
         run: flutter pub get && (cd demo && flutter pub get)
       - name: "Validate Dart formatting"

--- a/lib/src/scaffold.dart
+++ b/lib/src/scaffold.dart
@@ -710,10 +710,10 @@ class _MeasureSizeState extends State<_MeasureSize> {
 
   @override
   Widget build(BuildContext context) {
-    SchedulerBinding.instance!.addPostFrameCallback((_) => _notify());
+    SchedulerBinding.instance.addPostFrameCallback((_) => _notify());
     return NotificationListener<SizeChangedLayoutNotification>(
       onNotification: (_) {
-        SchedulerBinding.instance!.addPostFrameCallback((_) => _notify());
+        SchedulerBinding.instance.addPostFrameCallback((_) => _notify());
         return true;
       },
       child: SizeChangedLayoutNotifier(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ maintainer: Harsh Bhikadia (@daadu)
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
+  flutter: '>=2.12.0-4.0.pre'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Closes #122.

You may prefer to just ignore the warning, for backwards compatibility with flutter <= 2.10.

You could delay merging until flutter 2.13(?) becomes stable, or else publish a prerelease (say `v0.7.2-0`) that specifies a minimum flutter version in pubspec.yaml:

```yaml
environment:
  sdk: ">=2.17.0-0 <3.0.0"
  flutter:  ">=2.12.0-4.0.pre"
  # seems to be the first time flutter/flutter@ab89ce285 exists
```