### PR TITLE
concealable frontlayer when that's active by pressing back button on phone

### DIFF
--- a/lib/src/scaffold.dart
+++ b/lib/src/scaffold.dart
@@ -220,7 +220,6 @@ class BackdropScaffold extends StatefulWidget {
   /// Specifiy whether to conceal [backLayer] when back button pressed.
   ///
   /// Default to `true`.
-  final bool concealBacklayerOnBackButton;
 
   // ------------- PROPERTIES TAKEN OVER FROM SCAFFOLD ------------- //
 
@@ -336,7 +335,6 @@ class BackdropScaffold extends StatefulWidget {
     this.onBackLayerConcealed,
     this.onBackLayerRevealed,
     this.maintainBackLayerState = true,
-    this.concealBacklayerOnBackButton = true,
     this.scaffoldKey,
     this.appBar,
     this.floatingActionButton,
@@ -612,17 +610,16 @@ class BackdropScaffoldState extends State<BackdropScaffold>
       );
 
   Widget _wrapWillPopScope(BuildContext context, {required Widget child}) {
-    if (!widget.concealBacklayerOnBackButton) return child;
-    return WillPopScope(
-      onWillPop: () async {
-        if (isBackLayerRevealed) {
-          concealBackLayer();
+    if (!isBackLayerRevealed) {
+      return WillPopScope(
+        onWillPop: () async {
+          revealBackLayer();
           return false;
-        }
-        return true;
-      },
-      child: child,
-    );
+        },
+        child: child,
+      );
+    }
+    return child;
   }
 
   Widget _buildBody(BuildContext context) => _wrapWillPopScope(


### PR DESCRIPTION
By default, when the `frontLayer` widget  visibility is active, the user expects to hide it by pressing the back button. However, in the current version, this did not happen, and unfortunately, outside of this library, I was unable to hide the `frontLayer` widget. To achieve this, I removed the ‍`concealBacklayerOnBackButton‍` argument and modified the Scaffold class in this library. Now, this operation is successfully executed.